### PR TITLE
Add frontend deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,23 @@ twstock.realtime.get(['2330', '2337', '2409'])  # 擷取當前三檔資訊
 ## 使用範例
 
 * [tw-stocker](https://github.com/mlouielu/stocker)
+* `examples/frontend` 以 Flask 與 Chart.js 實作的簡易前端，可依股票代碼查詢即時價格並呈現 K 線圖。
+
+## 部署到 Render
+
+若要將範例前後端部署到 [Render](https://render.com)，可依下列步驟進行：
+
+1. Fork 本專案並登入 Render，建立新的 **Web Service**。
+2. 連結您的倉庫，並設定 `Build Command` 為：
+   ```bash
+   pip install -r examples/frontend/requirements.txt
+   ```
+3. 將 `Start Command` 設定為：
+   ```bash
+   python examples/frontend/app.py
+   ```
+4. 完成部署後，即可透過 Render 提供的網址存取網頁。
+
 
 ## Contributing
 

--- a/examples/frontend/README.md
+++ b/examples/frontend/README.md
@@ -1,0 +1,28 @@
+# Frontend Example
+
+This example demonstrates how to use `twstock` with a small Flask
+application. It allows users to query realtime prices by stock code and
+renders a candlestick chart using Chart.js.
+
+## Usage
+
+1. Install the required packages:
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+2. Run the application locally:
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:5000` in your browser and enter a stock code.
+
+### Deploying to Render
+
+在 Render 建立新的 **Web Service**，並將 `Build Command` 設定為：
+```bash
+pip install -r examples/frontend/requirements.txt
+```
+`Start Command` 則為：
+```bash
+python examples/frontend/app.py
+```

--- a/examples/frontend/app.py
+++ b/examples/frontend/app.py
@@ -1,0 +1,34 @@
+from flask import Flask, render_template, jsonify
+import twstock
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/api/price/<code>')
+def price(code):
+    data = twstock.realtime.get(code)
+    if data.get('success'):
+        return jsonify({'price': data['realtime']['latest_trade_price']})
+    return jsonify({'error': data.get('rtmessage', 'fetch error')}), 400
+
+@app.route('/api/candlestick/<code>')
+def candlestick(code):
+    stock = twstock.Stock(code)
+    stock.fetch_31()
+    result = [
+        {
+            't': d.date.strftime('%Y-%m-%d'),
+            'o': d.open,
+            'h': d.high,
+            'l': d.low,
+            'c': d.close,
+        }
+        for d in stock.data
+    ]
+    return jsonify(result)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/examples/frontend/requirements.txt
+++ b/examples/frontend/requirements.txt
@@ -1,0 +1,2 @@
+twstock
+flask

--- a/examples/frontend/templates/index.html
+++ b/examples/frontend/templates/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>TW Stock Viewer</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-financial"></script>
+</head>
+<body>
+<h1>TW Stock Viewer</h1>
+<input id="symbol" placeholder="2330"/>
+<button onclick="loadData()">Load</button>
+<div>
+    Current price: <span id="price"></span>
+</div>
+<canvas id="chart" width="800" height="400"></canvas>
+<script>
+async function loadData() {
+    const code = document.getElementById('symbol').value;
+    const priceRes = await fetch('/api/price/' + code);
+    const priceData = await priceRes.json();
+    document.getElementById('price').innerText = priceData.price || priceData.error;
+
+    const candleRes = await fetch('/api/candlestick/' + code);
+    const candlestick = await candleRes.json();
+    const ctx = document.getElementById('chart').getContext('2d');
+    if (window.candleChart) {
+        window.candleChart.destroy();
+    }
+    window.candleChart = new Chart(ctx, {
+        type: 'candlestick',
+        data: {datasets: [{label: code, data: candlestick}]},
+        options: {
+            parsing: {xAxisKey: 't', openKey: 'o', highKey: 'h', lowKey: 'l', closeKey: 'c'},
+            scales: {x: {type: 'time', time: {unit: 'day'}}}
+        }
+    });
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document Render deployment steps for the new frontend example
- add example requirements file for easier setup
- update example README

## Testing
- `python3 -m pip install -r examples/frontend/requirements.txt` *(fails: Could not find a version that satisfies the requirement twstock)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68453069265c8330b507908c4031eec8